### PR TITLE
Pull request 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,22 +165,25 @@ compress command usage:
     css    - compress all css files
     all    - compress all files
 
+    Use "compress <command> -h" to get
+    more information on a command.
+
 $ ./app compress js -h
 Usage of compress command: js:
-  -force=false: force compress file
-  -skip=false: skip all cached file
-  -v=false: verbose info
+  -force=false: force recreation of dist file
+  -skip=false: force recompression of all files
+  -v=false: verbose logging on/off
 
 $ ./app compress css -h
 Usage of compress command: css:
-  -force=false: force compress file
-  -skip=false: skip all cached file
-  -v=false: verbose info
+  -force=false: force recreation of dist file
+  -skip=false: force recompression of all files
+  -v=false: verbose logging on/off
 ```
 
 ```
-use -force for re-create dist file but not skip cached.
-use -skip can skip all cached file and re-compress.
+use -force to recreate the dist file (even if there are no changes to it)
+use -skip to force recompression of all files (even if they have not changed)
 ```
 
 ## Custom Compress

--- a/README.md
+++ b/README.md
@@ -1,32 +1,37 @@
 # Beego Compress
 
-Beego Compress provides an automated system for compressing JavaScript and Css files
+Beego Compress provides an automated system for compressing JavaScript and CSS files.
 
-It default use [Google Closure Compiler](https://code.google.com/p/closure-compiler/wiki/BinaryDownloads) for js, and [Yui Compressor](https://github.com/yui/yuicompressor/releases) for css
+By default, it uses the [Google Closure Compiler](https://code.google.com/p/closure-compiler/wiki/BinaryDownloads) for JS, and the [YUI Compressor](https://github.com/yui/yuicompressor/releases) for CSS.
+See [Customization Options](#customization-options) for how to changes these defaults.
 
 ## Sample Usage with Beego
 
-[After create a config file](#config-file), you can simple use it in beego.
+[After creating a config file](#config-file), you can simply use this library in your beego application by following the steps below:
 
-Move **compiler.jar** and **yuicompressor.jar** to your beego app path. Parallel with static path.
+Move **compiler.jar** and **yuicompressor.jar** to your beego applications main directory.
+This is usually the parent directory of your `static` asset directory.
 
-BTW: Of course you can integrated it with other framework or use it as a command line tool.
+BTW: This library does not depend on the main Beego framework.
+Therefore, you can easily integrate it with other frameworks, or use it in a standalone command line tool (see below).
+
+**Usage in your web application:**
 
 ```go
-func SettingCompress() {
-	// load json config file
-	isProductMode := false
-	setting, err := compress.LoadJsonConf("conf/compress.json", isProductMode, "http://127.0.0.1/")
+func SetupCompression() {
+	// Load JSON config file
+	isProductionMode := false
+	setting, err := compress.LoadJsonConf("conf/compress.json", isProductionMode, "http://127.0.0.1/")
 	if err != nil {
 		beego.Error(err)
 		return
 	}
 
-	// after use this api, can run command from shell.
-	setting.RunCommand()
+	// Uncomment the next line to enable usage as shown under "Command line usage":
+	// setting.RunCommand()
 
-	if isProductMode {
-		// if in product mode, can use this api auto compress files
+	if isProductionMode {
+		// For production mode: Use this method to automatically compress files.
 		setting.RunCompress(true, false, true)
 	}
 
@@ -36,7 +41,7 @@ func SettingCompress() {
 }
 ```
 
-In tempalte usage
+Usage in templates:
 
 ```html
 ...
@@ -49,9 +54,9 @@ In tempalte usage
 ...
 ```
 
-#### Congratulations!! Let's see html results.
+#### Congratulations! Let's look at the generated HTML:
 
-Render result when isProductMode is `false`
+Render result when isProductionMode is `false`:
 
 ```html
 <!-- Beego Compress group `lib` begin -->
@@ -73,7 +78,7 @@ Render result when isProductMode is `false`
 
 ```
 
-Render result when isProductMode is `true`
+Render result when isProductionMode is `true`:
 
 ```html
 <link rel="stylesheet" href="http://127.0.0.1:8092/static/css/lib.min.css?ver=1382346563" />
@@ -83,36 +88,36 @@ Render result when isProductMode is `true`
 
 ## Config file
 
-Full config file example.
+Full configuration file example.
 
-note: All json key are not case sensitive
+Note: All JSON key are not case sensitive.
 
 **compress.json:**
 
 ```
 {
 	"Js": {
-		// SrcPath is path of source file
+		// SrcPath is the path of (uncompressed) source file(s)
 		"SrcPath": "static_source/js",
-		// DistPath is path of compressed file
+		// DistPath is the path of compressed file(s)
 		"DistPath": "static/js",
-		// SrcURL is url prefix of source file
+		// SrcURL is the url prefix for the uncompressed files
 		"SrcURL": "static_source/js",
-		// DistURL is url prefix of compressed file
+		// DistURL is the url prefix for the compressed files
 		"DistURL": "static/js",
 		"Groups": {
-			// lib is the name of this compress group
+			// lib is the name of this compression group
 			"lib": {
-				// all compressed file will combined and save to DistFile
+				// All compressed files will be combined and saved to DistFile
 				"DistFile": "lib.min.js",
-				// source files of this group
+				// Source files of this group
 				"SourceFiles": [
 					"jquery.min.js",
 					"bootstrap.js",
 					"lib.min.js",
 					"jStorage.js"
 				],
-				// skip compress file list
+				// Files that should not be compressed
 				"SkipFiles": [
 					"jquery.min.js",
 					"lib.min.js"
@@ -128,7 +133,7 @@ note: All json key are not case sensitive
 		}
 	},
 	"Css": {
-		// config of css is same with js
+		// CSS configuration works analogous to JS configuration
 		"SrcPath": "static_source/css",
 		"DistPath": "static/css",
 		"SrcURL": "static_source/css",
@@ -152,9 +157,9 @@ note: All json key are not case sensitive
 }
 ```
 
-## Command mode
+## Command line usage
 
-when use api `setting.RunCommand()`
+When using the API `setting.RunCommand()`:
 
 ```
 $ go build app.go
@@ -186,19 +191,47 @@ use -force to recreate the dist file (even if there are no changes to it)
 use -skip to force recompression of all files (even if they have not changed)
 ```
 
-## Custom Compress
+Example application:
 
-All api can view in [GoWalker](http://gowalker.org/github.com/beego/compress)
+```go
+package main
 
-* [TmpPath](http://gowalker.org/github.com/beego/compress#_variables) is default path of cached files.
-* Can modify [JsFilters / CssFilters](http://gowalker.org/github.com/beego/compress#_variables) use your compress filter.
-* Can modify [JsTagTemplate / CssTagTemplate]((http://gowalker.org/github.com/beego/compress#_variables)) with your `<script>` `<link>` tag.
+import (
+	"github.com/beego/compress"
+)
 
-##  Contact and Issue
+func main() {
+	// Load JSON config file
+	isProductionMode := false
+	setting, err := compress.LoadJsonConf("conf/compress.json", isProductionMode, "http://127.0.0.1/")
+	if err != nil {
+		panic(err)
+	}
+
+	// Use this method to start the command when called from the shell.
+	// The arguments are read from os.Args.
+	setting.RunCommand()
+}
+
+```
+
+## Customization options
+
+The whole API can be viewed in [GoWalker](http://gowalker.org/github.com/beego/compress).
+
+* [TmpPath](http://gowalker.org/github.com/beego/compress#_variables) is the default path for caching generated files.
+
+* [JsFilters / CssFilters](http://gowalker.org/github.com/beego/compress#_variables) contains the slice of filter functions that are used to compress CSS and JS files, respectively.
+  The filters are applied in the same order as they are contained in the slice.
+  Each filter gets the output of the previous filter as its input.
+
+* [JsTagTemplate / CssTagTemplate](http://gowalker.org/github.com/beego/compress#_variables) is the [html/template.Template](http://golang.org/pkg/html/template/#Template) used to output `<script>` and `<link>` tags.
+
+##  Contact and Issue Tracking
 
 All beego projects need your support.
 
-Any suggestion are welcome, please [add new issue](https://github.com/beego/compress/issues/new) let me known.
+Any suggestions are welcome, please [add a new issue](https://github.com/beego/compress/issues/new) to let me know.
 
 ## LICENSE
 

--- a/cmd.go
+++ b/cmd.go
@@ -56,7 +56,9 @@ func printHelp(errs ...string) {
     js     - compress all js files
     css    - compress all css files
     all    - compress all files
-`
+
+    Use "compress <command> -h" to get
+    more information on a command.`
 
 	if len(errs) > 0 {
 		fmt.Println(errs[0])
@@ -82,9 +84,9 @@ func (d *compressAll) Parse(args []string) {
 		name = "css"
 	}
 	flagSet := flag.NewFlagSet("compress command: "+name, flag.ExitOnError)
-	flagSet.BoolVar(&d.force, "force", false, "force compress file")
-	flagSet.BoolVar(&d.skip, "skip", false, "skip all cached file")
-	flagSet.BoolVar(&d.verbose, "v", false, "verbose info")
+	flagSet.BoolVar(&d.force, "force", false, "force recreation of dist file")
+	flagSet.BoolVar(&d.skip, "skip", false, "force recompression of all files")
+	flagSet.BoolVar(&d.verbose, "v", false, "verbose logging on/off")
 	flagSet.Parse(args)
 }
 

--- a/compress.go
+++ b/compress.go
@@ -91,11 +91,11 @@ func compressFiles(c *compress, force, skip, verbose bool, filters []Filter) {
 
 				source := buf.String()
 				if verbose {
-					fmt.Fprintf(os.Stdout, "compress file %s ... ", sourceFile)
+					fmt.Fprintf(os.Stdout, "compressing file %s ... ", sourceFile)
 				}
 				if skips[file] {
 					if verbose {
-						fmt.Fprintf(os.Stdout, "skiped ")
+						fmt.Fprintf(os.Stdout, "skipping compression")
 					}
 				} else {
 					for _, filter := range filters {
@@ -112,7 +112,7 @@ func compressFiles(c *compress, force, skip, verbose bool, filters []Filter) {
 						if _, err := f.WriteString(source); err == nil {
 							hasModified = true
 							if verbose {
-								logInfo("saved")
+								logInfo("saved file")
 							}
 						} else {
 							writeErr = err
@@ -140,7 +140,7 @@ func compressFiles(c *compress, force, skip, verbose bool, filters []Filter) {
 				}
 
 				if verbose {
-					logInfo("use cache file %s", cacheFile)
+					logInfo("using cached file %s", cacheFile)
 				}
 				sources = append(sources, buf.String())
 			}

--- a/compress.go
+++ b/compress.go
@@ -1,3 +1,6 @@
+// Beego Compress provides an automated system for compressing JavaScript and CSS files.
+//
+// Please see README.md in the source code root for more information.
 package compress
 
 import (

--- a/compress.go
+++ b/compress.go
@@ -30,6 +30,10 @@ func logInfo(info string, args ...interface{}) {
 	fmt.Fprintln(os.Stdout, info)
 }
 
+func logInfoNoNewline(info string, args ...interface{}) {
+	fmt.Fprintf(os.Stdout, info, args...)
+}
+
 func compressFiles(c *compress, force, skip, verbose bool, filters []Filter) {
 	os.MkdirAll(TmpPath, 0755)
 
@@ -91,11 +95,11 @@ func compressFiles(c *compress, force, skip, verbose bool, filters []Filter) {
 
 				source := buf.String()
 				if verbose {
-					fmt.Fprintf(os.Stdout, "compressing file %s ... ", sourceFile)
+					logInfoNoNewline("compressing file %s ... ", sourceFile)
 				}
 				if skips[file] {
 					if verbose {
-						fmt.Fprintf(os.Stdout, "skipping compression")
+						logInfoNoNewline("skipping compression ... ")
 					}
 				} else {
 					for _, filter := range filters {
@@ -124,6 +128,9 @@ func compressFiles(c *compress, force, skip, verbose bool, filters []Filter) {
 				}
 
 				if writeErr != nil {
+					if verbose {
+						logInfo("")
+					}
 					logError("write error: %s", writeErr.Error())
 					hasError = true
 				}

--- a/compress.go
+++ b/compress.go
@@ -76,7 +76,7 @@ func compressFiles(c *compress, force, skip, verbose bool, filters []Filter) {
 					modified = true
 				}
 			} else {
-				logError("source file %s load error: %s", sourceFile, err.Error())
+				logError("source file [%s] load error: %s", sourceFile, err.Error())
 				hasError = true
 				continue
 			}
@@ -88,14 +88,14 @@ func compressFiles(c *compress, force, skip, verbose bool, filters []Filter) {
 					buf.ReadFrom(f)
 					f.Close()
 				} else {
-					logError("source file %s load error: %s", sourceFile, err.Error())
+					logError("source file [%s] load error: %s", sourceFile, err.Error())
 					hasError = true
 					continue
 				}
 
 				source := buf.String()
 				if verbose {
-					logInfoNoNewline("compressing file %s ... ", sourceFile)
+					logInfoNoNewline("compressing file [%s] ... ", sourceFile)
 				}
 				if skips[file] {
 					if verbose {
@@ -141,13 +141,13 @@ func compressFiles(c *compress, force, skip, verbose bool, filters []Filter) {
 				if f, err := os.Open(cacheFile); err == nil {
 					buf.ReadFrom(f)
 				} else {
-					logError("cache file %s load error: %s", cacheFile, err.Error())
+					logError("cache file [%s] load error: %s", cacheFile, err.Error())
 					hasError = true
 					continue
 				}
 
 				if verbose {
-					logInfo("using cached file %s", cacheFile)
+					logInfo("using cached file [%s]", cacheFile)
 				}
 				sources = append(sources, buf.String())
 			}
@@ -162,7 +162,7 @@ func compressFiles(c *compress, force, skip, verbose bool, filters []Filter) {
 					if f, err := os.OpenFile(distFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644); err == nil {
 						if _, err := f.WriteString(strings.Join(sources, "\n\n")); err == nil {
 							if verbose {
-								logInfo("compressed file %s ... saved", distFile)
+								logInfo("compressed file [%s] ... saved", distFile)
 							}
 						} else {
 							writeErr = err
@@ -175,7 +175,7 @@ func compressFiles(c *compress, force, skip, verbose bool, filters []Filter) {
 				}
 
 				if writeErr != nil {
-					logError("compressed file %s write error: %s", distFile, writeErr.Error())
+					logError("compressed file [%s] write error: %s", distFile, writeErr.Error())
 					hasError = true
 				}
 			} else {

--- a/conf.go
+++ b/conf.go
@@ -57,7 +57,7 @@ func NewCssCompress(srcPath, distPath, srcURL, distURL string, groups map[string
 	return compress
 }
 
-func LoadJsonConf(filePath string, proMode bool, staticURL string) (setting *Settings, err error) {
+func LoadJsonConf(filePath string, productionMode bool, staticURL string) (setting *Settings, err error) {
 	type Conf struct {
 		Js  *compressJs
 		Css *compressCss
@@ -96,8 +96,8 @@ func LoadJsonConf(filePath string, proMode bool, staticURL string) (setting *Set
 		staticURL = "/"
 	}
 
-	setting.Js.SetProMode(proMode)
-	setting.Css.SetProMode(proMode)
+	setting.Js.SetProMode(productionMode)
+	setting.Css.SetProMode(productionMode)
 
 	setting.Js.SetStaticURL(staticURL)
 	setting.Css.SetStaticURL(staticURL)

--- a/html.go
+++ b/html.go
@@ -102,7 +102,7 @@ func generateHTML(name string, c compress, t *template.Template) template.HTML {
 				filePath := filepath.Join(c.SrcPath, file)
 
 				if info, err := os.Stat(filePath); err == nil {
-					URL := c.StaticURL + path.Join(c.SrcPath, file) + "?ver=" + fmt.Sprint(info.ModTime().Unix())
+					URL := c.StaticURL + path.Join(c.SrcURL, file) + "?ver=" + fmt.Sprint(info.ModTime().Unix())
 
 					if res, err := parseTmpl(t, map[string]string{"URL": URL}); err != nil {
 						scripts = append(scripts, errHtml("template execution error: %s", err))

--- a/html.go
+++ b/html.go
@@ -68,21 +68,21 @@ func generateHTML(name string, c compress, t *template.Template) template.HTML {
 				return scripts
 			}
 
-			scripts := fmt.Sprintf("<script>/* Beego Compress Powered */</script>\n\t")
+			scripts := fmt.Sprintf("<script>/* Powered by Beego Compress */</script>\n\t")
 
 			filePath := filepath.Join(c.DistPath, group.DistFile)
 			if info, err := os.Stat(filePath); err == nil {
 				URL := c.StaticURL + path.Join(c.DistURL, group.DistFile) + "?ver=" + fmt.Sprint(info.ModTime().Unix())
 
 				if res, err := parseTmpl(t, map[string]string{"URL": URL}); err != nil {
-					errHtml("tempalte execute error: %s", err)
+					errHtml("template execution error: %s", err)
 
 				} else {
 					scripts += res
 				}
 
 			} else {
-				errHtml("load file `%s` for path `%s` error: %s", group.DistFile, filePath, err.Error())
+				errHtml("loading file `%s` from path `%s` failed: %s", group.DistFile, filePath, err.Error())
 			}
 
 			if len(scripts) > 0 {
@@ -102,14 +102,14 @@ func generateHTML(name string, c compress, t *template.Template) template.HTML {
 					URL := c.StaticURL + path.Join(c.SrcPath, file) + "?ver=" + fmt.Sprint(info.ModTime().Unix())
 
 					if res, err := parseTmpl(t, map[string]string{"URL": URL}); err != nil {
-						scripts = append(scripts, errHtml("tempalte execute error: %s", err))
+						scripts = append(scripts, errHtml("template execution error: %s", err))
 
 					} else {
 						scripts = append(scripts, res)
 					}
 
 				} else {
-					scripts = append(scripts, errHtml("load file `%s` for path `%s` error: %s", file, filePath, err.Error()))
+					scripts = append(scripts, errHtml("loading file `%s` from path `%s` failed: %s", file, filePath, err.Error()))
 				}
 			}
 
@@ -118,7 +118,7 @@ func generateHTML(name string, c compress, t *template.Template) template.HTML {
 			return template.HTML(strings.Join(scripts, "\n\t"))
 		}
 	} else {
-		return template.HTML(errHtml("not found compress group `%s`", name))
+		return template.HTML(errHtml("compression group `%s` was not found", name))
 	}
 
 	return ""

--- a/html.go
+++ b/html.go
@@ -68,6 +68,9 @@ func generateHTML(name string, c compress, t *template.Template) template.HTML {
 				return scripts
 			}
 
+			// NOTE: Because the generated HTMl might be inside an XML comment like <!--[if IE 7]>,
+			//       it cannot contain another XML comment (<!--...-->).
+			//       JavaScript comments provide a good workaround for this.
 			scripts := fmt.Sprintf("<script>/* Powered by Beego Compress */</script>\n\t")
 
 			filePath := filepath.Join(c.DistPath, group.DistFile)

--- a/html.go
+++ b/html.go
@@ -71,7 +71,7 @@ func generateHTML(name string, c compress, t *template.Template) template.HTML {
 			// NOTE: Because the generated HTMl might be inside an XML comment like <!--[if IE 7]>,
 			//       it cannot contain another XML comment (<!--...-->).
 			//       JavaScript comments provide a good workaround for this.
-			scripts := fmt.Sprintf("<script>/* Powered by Beego Compress */</script>\n\t")
+			scripts := "<script>/* Powered by Beego Compress */</script>\n\t"
 
 			filePath := filepath.Join(c.DistPath, group.DistFile)
 			if info, err := os.Stat(filePath); err == nil {
@@ -116,7 +116,7 @@ func generateHTML(name string, c compress, t *template.Template) template.HTML {
 				}
 			}
 
-			scripts = append(scripts, fmt.Sprintf("<script>/* end */</script>"))
+			scripts = append(scripts, "<script>/* end */</script>")
 
 			return template.HTML(strings.Join(scripts, "\n\t"))
 		}

--- a/html.go
+++ b/html.go
@@ -16,18 +16,18 @@ type Group struct {
 }
 
 type compress struct {
-	StaticURL string
-	SrcPath   string
-	DistPath  string
-	SrcURL    string
-	DistURL   string
-	Groups    map[string]Group
-	IsProMode bool
-	caches    map[string]template.HTML
+	StaticURL        string
+	SrcPath          string
+	DistPath         string
+	SrcURL           string
+	DistURL          string
+	Groups           map[string]Group
+	IsProductionMode bool
+	caches           map[string]template.HTML
 }
 
-func (c *compress) SetProMode(isPro bool) {
-	c.IsProMode = isPro
+func (c *compress) SetProMode(isProductionMode bool) {
+	c.IsProductionMode = isProductionMode
 }
 
 func (c *compress) SetStaticURL(url string) {
@@ -58,7 +58,7 @@ func (c *compressCss) CompressCss(name string) template.HTML {
 
 func generateHTML(name string, c compress, t *template.Template) template.HTML {
 	if group, ok := c.Groups[name]; ok {
-		if c.IsProMode {
+		if c.IsProductionMode {
 
 			if c.caches == nil {
 				c.caches = make(map[string]template.HTML, len(c.Groups))

--- a/html.go
+++ b/html.go
@@ -45,7 +45,7 @@ type compressJs struct {
 }
 
 func (c *compressJs) CompressJs(name string) template.HTML {
-	return generateHTML(name, c.compress, JsTagTemplate)
+	return generateHTML(name, &c.compress, JsTagTemplate)
 }
 
 type compressCss struct {
@@ -53,10 +53,10 @@ type compressCss struct {
 }
 
 func (c *compressCss) CompressCss(name string) template.HTML {
-	return generateHTML(name, c.compress, CssTagTemplate)
+	return generateHTML(name, &c.compress, CssTagTemplate)
 }
 
-func generateHTML(name string, c compress, t *template.Template) template.HTML {
+func generateHTML(name string, c *compress, t *template.Template) template.HTML {
 	if group, ok := c.Groups[name]; ok {
 		if c.IsProductionMode {
 


### PR DESCRIPTION
This pull request contains the following changes. Each item also corresponds to a branch mentioned below (see the [network graph](https://github.com/beego/compress/network) for a compact overview). In chronological order:
- Spelling fixes and improved wording for multiple code files and README.md (branch `pull-request/fix-spelling`).
- Renaming of internal `proMode` identifiers to `productionMode` (branch `pull-request/rename-production-mode`)
- Elimination of duplicated code in `html.go`. Also included is a bug fix where `c.SrcPath` was mistakenly used instead of `c.SrcURL` (branch `pull-request/refactor-html-generation`).
- Improvement of logging output done by `compress.go` (branch `pull-request/improve-logging-output`)

I can also split this pull request into four smaller ones, if this should be required.
